### PR TITLE
商品の編集カテゴリー

### DIFF
--- a/app/assets/javascripts/edit_category.js
+++ b/app/assets/javascripts/edit_category.js
@@ -42,7 +42,7 @@ $(document).on('turbolinks:load', function () {
                         <div class='form-require'>
                           必須
                         </div>
-                          <select class='select-default' name='item[delivery_id]' id='child_category'>
+                          <select class='select-default' name='item[delivery_id]' id='child_delivery_edit'>
                           <option value='---' data-category='---'>---</option>
                             ${insertHTML}
                           </div>
@@ -52,9 +52,9 @@ $(document).on('turbolinks:load', function () {
     $('.contents-box__category-section__category-box#async-select-boxsecond').append(deliverySelectHtml);
   }
 
-  // 子カテゴリー欄
-  $('#parent_category').on('change', function () {
-    var parentCategory = document.getElementById('parent_category').value
+  // 親カテゴリー欄
+  $('#parent_categoryedit').on('change', function () {
+    var parentCategory = document.getElementById('parent_categoryedit').value
     if (parentCategory != "---") {
 
       $.ajax({
@@ -64,8 +64,8 @@ $(document).on('turbolinks:load', function () {
         dataType: 'json'
       })
         .done(function (children) {
-          $('#child_category').remove();
-          $('#grandchild_category').remove();
+          $('#child_category_edit').remove();
+          $('#grandchild_category_edit').remove();
           var insertHTML = '';
           children.forEach(function (child) {
             insertHTML += appendOption(child);

--- a/app/assets/javascripts/edit_category.js
+++ b/app/assets/javascripts/edit_category.js
@@ -76,14 +76,13 @@ $(document).on('turbolinks:load', function () {
           alert('カテゴリー取得に失敗しました');
         })
     } else {
-      $('#child_category').remove();
-      $('#grandchild_category').remove();
+      $('#grandchild_category_edit').remove();
     }
   });
 
-  // 孫カテゴリー欄
-  $('.contents-box__category-section__category-box__tag#async-select-box').on('change', '#child_category', function () {
-    var childId = $('#child_category option:selected').data('category');
+  // 子カテゴリー欄
+  $('.contents-box__category-section__category-box__tag#async-select-box').on('change', '#child_category_edit', function () {
+    var childId = $('#child_category_edit option:selected').data('category');
     if (childId != "---") {
       $.ajax({
         url: 'category_grandchildren',
@@ -93,7 +92,7 @@ $(document).on('turbolinks:load', function () {
       })
         .done(function (grandchildren) {
           if (grandchildren.length != 0) {
-            $('#grandchild_category').remove();
+            $('#grandchild_category_edit').remove();
             var insertHTML = '';
             grandchildren.forEach(function (grandchild) {
               insertHTML += appendOption(grandchild);
@@ -105,12 +104,12 @@ $(document).on('turbolinks:load', function () {
           alert('カテゴリー取得に失敗しました');
         })
     } else {
-      $('#grandchild_category').remove();
+      $('#grandchild_category_edit').remove();
     }
   });
 
   // デリバリー欄
-  $('#delivery_category').on('change', function () {
+  $('#parent_delivery_edit').on('change', function () {
     var parentDelivery = document.getElementById('delivery_category').value
     if (parentDelivery != "---") {
       $.ajax({

--- a/app/assets/javascripts/edit_category.js
+++ b/app/assets/javascripts/edit_category.js
@@ -7,7 +7,7 @@ $(document).on('turbolinks:load', function () {
   function appendChildrenBox(insertHTML) {
     var childSelectHtml = '';
     childSelectHtml = `
-                      <select class='select-default' name='item[category_id]' id='child_category_edit'>
+                      <select class='select-default' name='item[child]' id='child_category_edit'>
                         <option value='---' data-category='---'>---</option>
                           ${insertHTML}
                       </select>
@@ -37,7 +37,7 @@ $(document).on('turbolinks:load', function () {
     var deliverySelectHtml = '';
     deliverySelectHtml = `
                         <div class='contents-box__category-section__category-box__tag#async-select-boxsecond'>
-                        <div class='contents-box__category-section__category-box__tag' id='delivery-method'>
+                        <div class='contents-box__category-section__category-box__tag' id='parent_delivery_edit'>
                           配送の方法
                         <div class='form-require'>
                           必須

--- a/app/assets/javascripts/edit_category.js
+++ b/app/assets/javascripts/edit_category.js
@@ -1,0 +1,136 @@
+$(document).on('turbolinks:load', function () {
+  function appendOption(category) {
+    var html = `<option value="${category.id}" data-category="${category.id}">${category.name}</option>`;
+    return html;
+  }
+  // 子カテゴリー
+  function appendChildrenBox(insertHTML) {
+    var childSelectHtml = '';
+    childSelectHtml = `
+                      <select class='select-default' name='item[child]' id='child_category_edit'>
+                        <option value='---' data-category='---'>---</option>
+                          ${insertHTML}
+                      </select>
+                      `;
+    $('.contents-box__category-section__category-box__tag#async-select-box').append(childSelectHtml);
+  }
+
+  // 孫カテゴリー
+  function appendGrandchildBox(insertHTML) {
+    var grandchildSelectHtml = '';
+    grandchildSelectHtml = `
+                      <select class='select-default' name='item[category_id]' id='grandchild_category_edit'>
+                        <option value='---' data-category='---'>---</option>
+                          ${insertHTML}
+                      </select>
+                      `;
+    $('.contents-box__category-section__category-box__tag#async-select-box').append(grandchildSelectHtml);
+  }
+
+  function appendOptionsecond(delivery) {
+    var html = `<option value="${delivery.id}" data-category="${delivery.id}">${delivery.name}</option>`;
+    return html;
+  }
+
+  // 子デリバリー
+  function appendDeliveryChildrenBox(insertHTML) {
+    var deliverySelectHtml = '';
+    deliverySelectHtml = `
+                        <div class='contents-box__category-section__category-box__tag#async-select-boxsecond'>
+                        <div class='contents-box__category-section__category-box__tag' id='delivery-method'>
+                          配送の方法
+                        <div class='form-require'>
+                          必須
+                        </div>
+                          <select class='select-default' name='item[delivery_id]' id='child_category'>
+                          <option value='---' data-category='---'>---</option>
+                            ${insertHTML}
+                          </div>
+                        </select>
+                        </div>
+                      `;
+    $('.contents-box__category-section__category-box#async-select-boxsecond').append(deliverySelectHtml);
+  }
+
+  // 子カテゴリー欄
+  $('#parent_category').on('change', function () {
+    var parentCategory = document.getElementById('parent_category').value
+    if (parentCategory != "---") {
+
+      $.ajax({
+        url: 'category_children',
+        type: 'GET',
+        data: { name: parentCategory },
+        dataType: 'json'
+      })
+        .done(function (children) {
+          $('#child_category').remove();
+          $('#grandchild_category').remove();
+          var insertHTML = '';
+          children.forEach(function (child) {
+            insertHTML += appendOption(child);
+          });
+          appendChildrenBox(insertHTML);
+        })
+        .fail(function () {
+          alert('カテゴリー取得に失敗しました');
+        })
+    } else {
+      $('#child_category').remove();
+      $('#grandchild_category').remove();
+    }
+  });
+
+  // 孫カテゴリー欄
+  $('.contents-box__category-section__category-box__tag#async-select-box').on('change', '#child_category', function () {
+    var childId = $('#child_category option:selected').data('category');
+    if (childId != "---") {
+      $.ajax({
+        url: 'category_grandchildren',
+        type: 'GET',
+        data: { child_id: childId },
+        dataType: 'json'
+      })
+        .done(function (grandchildren) {
+          if (grandchildren.length != 0) {
+            $('#grandchild_category').remove();
+            var insertHTML = '';
+            grandchildren.forEach(function (grandchild) {
+              insertHTML += appendOption(grandchild);
+            });
+            appendGrandchildBox(insertHTML);
+          }
+        })
+        .fail(function () {
+          alert('カテゴリー取得に失敗しました');
+        })
+    } else {
+      $('#grandchild_category').remove();
+    }
+  });
+
+  // デリバリー欄
+  $('#delivery_category').on('change', function () {
+    var parentDelivery = document.getElementById('delivery_category').value
+    if (parentDelivery != "---") {
+      $.ajax({
+        url: 'delivery_children',
+        type: 'GET',
+        data: { name: parentDelivery },
+        dataType: 'json'
+      })
+        .done(function (children_second) {
+          var insertHTML = '';
+          children_second.forEach(function (children_second) {
+            insertHTML += appendOptionsecond(children_second);
+          });
+          appendDeliveryChildrenBox(insertHTML);
+        })
+        .fail(function () {
+          alert('カテゴリー取得に失敗しました');
+        })
+    } else {
+      $('#grandchild_category').remove();
+    }
+  });
+});

--- a/app/assets/javascripts/edit_category.js
+++ b/app/assets/javascripts/edit_category.js
@@ -110,7 +110,7 @@ $(document).on('turbolinks:load', function () {
 
   // デリバリー欄
   $('#parent_delivery_edit').on('change', function () {
-    var parentDelivery = document.getElementById('delivery_category').value
+    var parentDelivery = document.getElementById('parent_delivery_edit').value
     if (parentDelivery != "---") {
       $.ajax({
         url: 'delivery_children',
@@ -119,6 +119,9 @@ $(document).on('turbolinks:load', function () {
         dataType: 'json'
       })
         .done(function (children_second) {
+          $('#async-select-boxthird').empty();
+          $('#delivery-method_edit').remove();
+          $('#child_delivery_edit').remove();
           var insertHTML = '';
           children_second.forEach(function (children_second) {
             insertHTML += appendOptionsecond(children_second);
@@ -129,7 +132,7 @@ $(document).on('turbolinks:load', function () {
           alert('カテゴリー取得に失敗しました');
         })
     } else {
-      $('#grandchild_category').remove();
+      $('#grandchild_category_edit').remove();
     }
   });
 });

--- a/app/assets/javascripts/edit_category.js
+++ b/app/assets/javascripts/edit_category.js
@@ -56,9 +56,8 @@ $(document).on('turbolinks:load', function () {
   $('#parent_categoryedit').on('change', function () {
     var parentCategory = document.getElementById('parent_categoryedit').value
     if (parentCategory != "---") {
-
       $.ajax({
-        url: 'category_children',
+        url: '/items/category_children',
         type: 'GET',
         data: { name: parentCategory },
         dataType: 'json'
@@ -72,7 +71,10 @@ $(document).on('turbolinks:load', function () {
           });
           appendChildrenBox(insertHTML);
         })
-        .fail(function () {
+        .fail(function (a, b, c) {
+          console.log(a.status)
+          console.log(b)
+          console.log(c)
           alert('カテゴリー取得に失敗しました');
         })
     } else {
@@ -85,7 +87,7 @@ $(document).on('turbolinks:load', function () {
     var childId = $('#child_category_edit option:selected').data('category');
     if (childId != "---") {
       $.ajax({
-        url: 'category_grandchildren',
+        url: '/items/category_grandchildren',
         type: 'GET',
         data: { child_id: childId },
         dataType: 'json'
@@ -113,7 +115,7 @@ $(document).on('turbolinks:load', function () {
     var parentDelivery = document.getElementById('parent_delivery_edit').value
     if (parentDelivery != "---") {
       $.ajax({
-        url: 'delivery_children',
+        url: '/items/delivery_children',
         type: 'GET',
         data: { name: parentDelivery },
         dataType: 'json'

--- a/app/assets/javascripts/edit_category.js
+++ b/app/assets/javascripts/edit_category.js
@@ -7,7 +7,7 @@ $(document).on('turbolinks:load', function () {
   function appendChildrenBox(insertHTML) {
     var childSelectHtml = '';
     childSelectHtml = `
-                      <select class='select-default' name='item[child]' id='child_category_edit'>
+                      <select class='select-default' name='item[category_id]' id='child_category_edit'>
                         <option value='---' data-category='---'>---</option>
                           ${insertHTML}
                       </select>

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -36,6 +36,12 @@ class ItemsController < ApplicationController
     @category_child_array = @item.category.parent.parent.children
     @category_grandchild_array = @item.category.parent.children
 
+    @delivery_parent_array = ['---']
+    Delivery.where(ancestry: nil).each do |parent|
+      @delivery_parent_array << parent.delivery_method
+    end
+    @delivery_child_array = @item.delivery.parent.children
+
       # @grandchild = Category.find(@item[:category_id])
       # @child = @grandchild.parent
       # @parent = @child.parent
@@ -61,18 +67,18 @@ class ItemsController < ApplicationController
       #   @category_parents_array << parent_hash
       # end
 
-      @selected_child_delivery = @item.delivery
-      @delivery_children_array = [{id: "---", name: "---"}]
-      Delivery.find("#{@selected_child_delivery.id}").siblings.each do |child|
-        children_hash = {id: "#{child.id}", name: "#{child.name}"}
-        @delivery_children_array << children_hash
-      end
-      @selected_parent_delivery = @selected_child_delivery.parent
-      @delivery_parents_array = [{id: "---", name: "---"}]
-      Delivery.find("#{@selected_parent_delivery.id}").siblings.each do |parent|
-        parent_hash = {id: "#{parent.id}", name: "#{parent.name}"}
-        @delivery_parents_array << parent_hash
-      end
+      # @selected_child_delivery = @item.delivery
+      # @delivery_children_array = [{id: "---", name: "---"}]
+      # Delivery.find("#{@selected_child_delivery.id}").siblings.each do |child|
+      #   children_hash = {id: "#{child.id}", name: "#{child.name}"}
+      #   @delivery_children_array << children_hash
+      # end
+      # @selected_parent_delivery = @selected_child_delivery.parent
+      # @delivery_parents_array = [{id: "---", name: "---"}]
+      # Delivery.find("#{@selected_parent_delivery.id}").siblings.each do |parent|
+      #   parent_hash = {id: "#{parent.id}", name: "#{parent.name}"}
+      #   @delivery_parents_array << parent_hash
+      # end
 
       @bland = Bland.pluck(:name, :id)
     

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -27,30 +27,30 @@ class ItemsController < ApplicationController
   # 商品詳細の編集
   def edit
     if user_signed_in? && current_user.id == @item.user_id_id
-      @grandchild = Category.find(@item[:category_id])
-      @child = @grandchild.parent
-      @parent = @child.parent
-      @delivery = Delivery.find(@item[:delivery_id])
-      @charge = @delivery.parent
+      # @grandchild = Category.find(@item[:category_id])
+      # @child = @grandchild.parent
+      # @parent = @child.parent
+      # @delivery = Delivery.find(@item[:delivery_id])
+      # @charge = @delivery.parent
 
-      @selected_grandchild_category = @item.category
-      @category_grandchildren_array = [{id: "---", name: "---"}]
-      Category.find("#{@selected_grandchild_category.id}").siblings.each do |grandchild|
-        grandchildren_hash = {id: "#{grandchild.id}", name: "#{grandchild.name}"}
-        @category_grandchildren_array << grandchildren_hash
-      end
-      @selected_child_category = @selected_grandchild_category.parent
-      @category_children_array = [{id: "---", name: "---"}]
-      Category.find("#{@selected_child_category.id}").siblings.each do |child|
-        children_hash = {id: "#{child.id}", name: "#{child.name}"}
-        @category_children_array << children_hash
-      end
-      @selected_parent_category = @selected_child_category.parent
-      @category_parents_array = [{id: "---", name: "---"}]
-      Category.find("#{@selected_parent_category.id}").siblings.each do |parent|
-        parent_hash = {id: "#{parent.id}", name: "#{parent.name}"}
-        @category_parents_array << parent_hash
-      end
+      # @selected_grandchild_category = @item.category
+      # @category_grandchildren_array = [{id: "---", name: "---"}]
+      # Category.find("#{@selected_grandchild_category.id}").siblings.each do |grandchild|
+      #   grandchildren_hash = {id: "#{grandchild.id}", name: "#{grandchild.name}"}
+      #   @category_grandchildren_array << grandchildren_hash
+      # end
+      # @selected_child_category = @selected_grandchild_category.parent
+      # @category_children_array = [{id: "---", name: "---"}]
+      # Category.find("#{@selected_child_category.id}").siblings.each do |child|
+      #   children_hash = {id: "#{child.id}", name: "#{child.name}"}
+      #   @category_children_array << children_hash
+      # end
+      # @selected_parent_category = @selected_child_category.parent
+      # @category_parents_array = [{id: "---", name: "---"}]
+      # Category.find("#{@selected_parent_category.id}").siblings.each do |parent|
+      #   parent_hash = {id: "#{parent.id}", name: "#{parent.name}"}
+      #   @category_parents_array << parent_hash
+      # end
 
       @selected_child_delivery = @item.delivery
       @delivery_children_array = [{id: "---", name: "---"}]

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -28,21 +28,14 @@ class ItemsController < ApplicationController
   def edit
     if user_signed_in? && current_user.id == @item.user_id_id
 
-      @category_parent_array = []
-      Category.where(ancestry: nil).each do |parent_category|
-      @category_parent_array << parent_category
-    end
-
+    @category_parent_array = Category.roots
     @category_child_array = @item.category.parent.parent.children
     @category_grandchild_array = @item.category.parent.children
 
-    @delivery_parent_array = []
-    Delivery.where(ancestry: nil).each do |parent_delivery|
-      @delivery_parent_array << parent_delivery
-    end
+    @delivery_parent_array = Delivery.roots
     @delivery_child_array = @item.delivery.parent.children
 
-      @bland = Bland.pluck(:name, :id)
+    @bland = Bland.pluck(:name, :id)
     elsif user_signed_in?
       redirect_to(root_path)
     else

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -29,59 +29,20 @@ class ItemsController < ApplicationController
     if user_signed_in? && current_user.id == @item.user_id_id
 
       @category_parent_array = []
-      Category.where(ancestry: nil).each do |parent|
-      @category_parent_array << parent
+      Category.where(ancestry: nil).each do |parent_category|
+      @category_parent_array << parent_category
     end
 
     @category_child_array = @item.category.parent.parent.children
     @category_grandchild_array = @item.category.parent.children
 
     @delivery_parent_array = []
-    Delivery.where(ancestry: nil).each do |parent|
-      @delivery_parent_array << parent
+    Delivery.where(ancestry: nil).each do |parent_delivery|
+      @delivery_parent_array << parent_delivery
     end
     @delivery_child_array = @item.delivery.parent.children
 
-      # @grandchild = Category.find(@item[:category_id])
-      # @child = @grandchild.parent
-      # @parent = @child.parent
-      # @delivery = Delivery.find(@item[:delivery_id])
-      # @charge = @delivery.parent
-
-      # @selected_grandchild_category = @item.category
-      # @category_grandchildren_array = [{id: "---", name: "---"}]
-      # Category.find("#{@selected_grandchild_category.id}").siblings.each do |grandchild|
-      #   grandchildren_hash = {id: "#{grandchild.id}", name: "#{grandchild.name}"}
-      #   @category_grandchildren_array << grandchildren_hash
-      # end
-      # @selected_child_category = @selected_grandchild_category.parent
-      # @category_children_array = [{id: "---", name: "---"}]
-      # Category.find("#{@selected_child_category.id}").siblings.each do |child|
-      #   children_hash = {id: "#{child.id}", name: "#{child.name}"}
-      #   @category_children_array << children_hash
-      # end
-      # @selected_parent_category = @selected_child_category.parent
-      # @category_parents_array = [{id: "---", name: "---"}]
-      # Category.find("#{@selected_parent_category.id}").siblings.each do |parent|
-      #   parent_hash = {id: "#{parent.id}", name: "#{parent.name}"}
-      #   @category_parents_array << parent_hash
-      # end
-
-      # @selected_child_delivery = @item.delivery
-      # @delivery_children_array = [{id: "---", name: "---"}]
-      # Delivery.find("#{@selected_child_delivery.id}").siblings.each do |child|
-      #   children_hash = {id: "#{child.id}", name: "#{child.name}"}
-      #   @delivery_children_array << children_hash
-      # end
-      # @selected_parent_delivery = @selected_child_delivery.parent
-      # @delivery_parents_array = [{id: "---", name: "---"}]
-      # Delivery.find("#{@selected_parent_delivery.id}").siblings.each do |parent|
-      #   parent_hash = {id: "#{parent.id}", name: "#{parent.name}"}
-      #   @delivery_parents_array << parent_hash
-      # end
-
       @bland = Bland.pluck(:name, :id)
-    
     elsif user_signed_in?
       redirect_to(root_path)
     else

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -30,7 +30,7 @@ class ItemsController < ApplicationController
 
       @category_parents_array = ['---']
       Category.where(ancestry: nil).each do |parent|
-      @category_parent_array << parent.category_name
+      @category_parent_array << parent
     end
 
     @category_child_array = @item.category.parent.parent.children
@@ -38,7 +38,7 @@ class ItemsController < ApplicationController
 
     @delivery_parent_array = ['---']
     Delivery.where(ancestry: nil).each do |parent|
-      @delivery_parent_array << parent.delivery_method
+      @delivery_parent_array << parent
     end
     @delivery_child_array = @item.delivery.parent.children
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -33,6 +33,9 @@ class ItemsController < ApplicationController
       @category_parent_array << parent.category_name
     end
 
+    @category_child_array = @item.category.parent.parent.children
+    @category_grandchild_array = @item.category.parent.children
+
       # @grandchild = Category.find(@item[:category_id])
       # @child = @grandchild.parent
       # @parent = @child.parent

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -28,7 +28,7 @@ class ItemsController < ApplicationController
   def edit
     if user_signed_in? && current_user.id == @item.user_id_id
 
-      @category_parents_array = ['---']
+      @category_parent_array = ['---']
       Category.where(ancestry: nil).each do |parent|
       @category_parent_array << parent
     end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -28,7 +28,7 @@ class ItemsController < ApplicationController
   def edit
     if user_signed_in? && current_user.id == @item.user_id_id
 
-      @category_parent_array = ['---']
+      @category_parent_array = []
       Category.where(ancestry: nil).each do |parent|
       @category_parent_array << parent
     end
@@ -36,7 +36,7 @@ class ItemsController < ApplicationController
     @category_child_array = @item.category.parent.parent.children
     @category_grandchild_array = @item.category.parent.children
 
-    @delivery_parent_array = ['---']
+    @delivery_parent_array = []
     Delivery.where(ancestry: nil).each do |parent|
       @delivery_parent_array << parent
     end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -27,6 +27,12 @@ class ItemsController < ApplicationController
   # 商品詳細の編集
   def edit
     if user_signed_in? && current_user.id == @item.user_id_id
+
+      @category_parents_array = ['---']
+      Category.where(ancestry: nil).each do |parent|
+      @category_parent_array << parent.category_name
+    end
+
       # @grandchild = Category.find(@item[:category_id])
       # @child = @grandchild.parent
       # @parent = @child.parent

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -91,7 +91,7 @@
             .form-require
               必須
             = f.select :delivery, options_for_select(@delivery_parent_array.map{|c|[c, {}]}, @item.delivery.parent.delivery_method), {}, {class: 'select-default', id: 'parent_delivery_edit'}
-          .contents-box__category-section__category-box__tag
+          .contents-box__category-section__category-box__tag#async-select-boxthird
             配送の方法
             .form-require
               必須

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -56,7 +56,7 @@
             カテゴリー
             .form-require
               必須
-            = f.select :category_id, options_for_select(@category_parent_array.map{|c|[c, {}]}, @item.category.id), {}, {class: 'select-default', id: 'parent_categoryedit'}
+            = f.select :category_id, options_for_select(@category_parent_array.map{|c|[c[:name], c[:id], {'data-category'=>c[:id], 'id'=>c[:id]}]}, @item.category.parent.parent.name), {}, {class: 'select-default', id: 'parent_categoryedit'}
             = f.select :category_id, options_for_select(@category_child_array.map{|c|[c[:name], c[:id], {'data-category'=>c[:id], 'id'=>c[:id]}]}, @item.category.parent.id), {}, {class: 'select-default', id: 'child_category_edit'}
             = f.select :category_id, options_for_select(@category_grandchild_array.map{|c|[c[:name], c[:id], {'data-category'=>c[:id], 'id'=>c[:id]}]}, @item.category.id), {}, {class: 'select-default', id: 'grandchild_category_edit' }
           = f.text_field :category, id: 'grand_child_result_id', type: 'hidden'
@@ -90,7 +90,7 @@
             配送料の負担
             .form-require
               必須
-            = f.select :delivery, options_for_select(@delivery_parent_array.map{|c|[c, {}]}, @item.delivery.parent.name), {}, {class: 'select-default', id: 'parent_delivery_edit'}
+            = f.select :delivery, options_for_select(@delivery_parent_array.map{|c|[c[:name], c[:id], {'data-category'=>c[:id], 'id'=>c[:id]}]}, @item.delivery.parent.name), {}, {class: 'select-default', id: 'parent_delivery_edit'}
           .contents-box__category-section__category-box__tag#async-select-boxthird
             配送の方法
             .form-require

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -56,10 +56,10 @@
             カテゴリー
             .form-require
               必須
-            = f.select :category_id, options_for_select(@category_parents_array.map{|c|[c[:name], c[:name]]}, @selected_parent_category.name), {}, {class: 'select-default', id: 'parent_category1'}
-            = f.select :category_id, options_for_select(@category_children_array.map{|c|[c[:name], c[:id], {'data-category'=>c[:id]}]}, @selected_child_category.id), {}, {class: 'select-default', id: 'child_category1'}
-            = f.select :category_id, options_for_select(@category_grandchildren_array.map{|c|[c[:name], c[:id], {'data-category'=>c[:id]}]}, @selected_grandchild_category.id), {}, {class: 'select-default', id: 'grandchild_category1'}
-
+            = f.select :parent, options_for_select(@category_parents_array.map{|c|[c, {}]}, @item.category.parent.parent.category_name), {}, {class: 'select-default', id: 'parent_categoryedit'}
+            = f.select :child, options_for_select(@category_child_array.map{|c|[c[:name], c[:id], {'data-category'=>c[:id], 'id'=>c[:id]}]}, @item.category.parent.id), {}, {class: 'category', id: 'child_category__edit'}
+            = f.select :category_id, options_for_select(@category_grandchild_array.map{|c|[c[:name], c[:id], {'data-category'=>c[:id], 'id'=>c[:id]}]}, @item.category.id), {}, {class: 'category', id: 'grandchild_category__edit' }
+          = f.text_field :category, id: 'grand_child_result_id', type: 'hidden'
           .contents-box__category-section__category-box__tag#size
             サイズ
             .form-require

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -57,8 +57,8 @@
             .form-require
               必須
             = f.select :parent, options_for_select(@category_parents_array.map{|c|[c, {}]}, @item.category.parent.parent.category_name), {}, {class: 'select-default', id: 'parent_categoryedit'}
-            = f.select :child, options_for_select(@category_child_array.map{|c|[c[:name], c[:id], {'data-category'=>c[:id], 'id'=>c[:id]}]}, @item.category.parent.id), {}, {class: 'category', id: 'child_category__edit'}
-            = f.select :category_id, options_for_select(@category_grandchild_array.map{|c|[c[:name], c[:id], {'data-category'=>c[:id], 'id'=>c[:id]}]}, @item.category.id), {}, {class: 'category', id: 'grandchild_category__edit' }
+            = f.select :child, options_for_select(@category_child_array.map{|c|[c[:name], c[:id], {'data-category'=>c[:id], 'id'=>c[:id]}]}, @item.category.parent.id), {}, {class: 'category', id: 'child_category_edit'}
+            = f.select :category_id, options_for_select(@category_grandchild_array.map{|c|[c[:name], c[:id], {'data-category'=>c[:id], 'id'=>c[:id]}]}, @item.category.id), {}, {class: 'category', id: 'grandchild_category_edit' }
           = f.text_field :category, id: 'grand_child_result_id', type: 'hidden'
           .contents-box__category-section__category-box__tag#size
             サイズ
@@ -90,12 +90,12 @@
             配送料の負担
             .form-require
               必須
-            = f.select :delivery_id, options_for_select(@delivery_parents_array.map{|c|[c[:name], c[:name]]}, @selected_parent_delivery.name), {}, {class: 'select-default', id: 'parent_category1'}
+            = f.select :delivery, options_for_select(@delivery_parent_array.map{|c|[c, {}]}, @item.delivery.parent.delivery_method), {}, {class: 'select-default', id: 'parent_delivery__edit'}
           .contents-box__category-section__category-box__tag
             配送の方法
             .form-require
               必須
-            = f.select :delivery_id, options_for_select(@delivery_children_array.map{|c|[c[:name], c[:id], {'data-category'=>c[:id]}]}, @selected_child_delivery.id), {}, {class: 'select-default', id: 'child_category1'}
+            = f.select :delivery_id, options_for_select(@delivery_child_array.map{|c|[c[:delivery_method], c[:id], {'data-category'=>c[:id], 'id'=>c[:id]}]}, @item.delivery.id), {}, {class: 'select-default', id: 'child_delivery__edit'}
         .contents-box__category-section__category-box
           .contents-box__category-section__category-box__tag
             発送元の地域

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -56,9 +56,9 @@
             カテゴリー
             .form-require
               必須
-            = f.select :parent, options_for_select(@category_parent_array.map{|c|[c, {}]}, @item.category.parent.parent.name), {}, {class: 'select-default', id: 'parent_categoryedit'}
-            = f.select :child, options_for_select(@category_child_array.map{|c|[c[:name], c[:id], {'data-category'=>c[:id], 'id'=>c[:id]}]}, @item.category.parent.id), {}, {class: 'category', id: 'child_category_edit'}
-            = f.select :category_id, options_for_select(@category_grandchild_array.map{|c|[c[:name], c[:id], {'data-category'=>c[:id], 'id'=>c[:id]}]}, @item.category.id), {}, {class: 'category', id: 'grandchild_category_edit' }
+            = f.select :category_id, options_for_select(@category_parent_array.map{|c|[c, {}]}, @item.category.id), {}, {class: 'select-default', id: 'parent_categoryedit'}
+            = f.select :category_id, options_for_select(@category_child_array.map{|c|[c[:name], c[:id], {'data-category'=>c[:id], 'id'=>c[:id]}]}, @item.category.parent.id), {}, {class: 'select-default', id: 'child_category_edit'}
+            = f.select :category_id, options_for_select(@category_grandchild_array.map{|c|[c[:name], c[:id], {'data-category'=>c[:id], 'id'=>c[:id]}]}, @item.category.id), {}, {class: 'select-default', id: 'grandchild_category_edit' }
           = f.text_field :category, id: 'grand_child_result_id', type: 'hidden'
           .contents-box__category-section__category-box__tag#size
             サイズ

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -13,7 +13,7 @@
   .contents-box
     %section.contents-box__sell-container
       商品の情報を入力
-    = form_with model: @item, class: 'contents-box__form-list' do |f|
+    = form_with model: @item, class: 'contents-box__form-list', id: 'edit_item' do |f|
       -# 画像アップロード部分
       %section.contents-box__form-list__upload-box
         .contents-box__form-list__upload-box__image-text
@@ -56,7 +56,7 @@
             カテゴリー
             .form-require
               必須
-            = f.select :parent, options_for_select(@category_parents_array.map{|c|[c, {}]}, @item.category.parent.parent.category_name), {}, {class: 'select-default', id: 'parent_categoryedit'}
+            = f.select :parent, options_for_select(@category_parent_array.map{|c|[c, {}]}, @item.category.parent.parent.name), {}, {class: 'select-default', id: 'parent_categoryedit'}
             = f.select :child, options_for_select(@category_child_array.map{|c|[c[:name], c[:id], {'data-category'=>c[:id], 'id'=>c[:id]}]}, @item.category.parent.id), {}, {class: 'category', id: 'child_category_edit'}
             = f.select :category_id, options_for_select(@category_grandchild_array.map{|c|[c[:name], c[:id], {'data-category'=>c[:id], 'id'=>c[:id]}]}, @item.category.id), {}, {class: 'category', id: 'grandchild_category_edit' }
           = f.text_field :category, id: 'grand_child_result_id', type: 'hidden'
@@ -90,12 +90,12 @@
             配送料の負担
             .form-require
               必須
-            = f.select :delivery, options_for_select(@delivery_parent_array.map{|c|[c, {}]}, @item.delivery.parent.delivery_method), {}, {class: 'select-default', id: 'parent_delivery_edit'}
+            = f.select :delivery, options_for_select(@delivery_parent_array.map{|c|[c, {}]}, @item.delivery.parent.name), {}, {class: 'select-default', id: 'parent_delivery_edit'}
           .contents-box__category-section__category-box__tag#async-select-boxthird
             配送の方法
             .form-require
               必須
-            = f.select :delivery_id, options_for_select(@delivery_child_array.map{|c|[c[:delivery_method], c[:id], {'data-category'=>c[:id], 'id'=>c[:id]}]}, @item.delivery.id), {}, {class: 'select-default', id: 'child_delivery_edit'}
+            = f.select :delivery_id, options_for_select(@delivery_child_array.map{|c|[c[:name], c[:id], {'data-category'=>c[:id], 'id'=>c[:id]}]}, @item.delivery.id), {}, {class: 'select-default', id: 'child_delivery_edit'}
         .contents-box__category-section__category-box
           .contents-box__category-section__category-box__tag
             発送元の地域

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -90,12 +90,12 @@
             配送料の負担
             .form-require
               必須
-            = f.select :delivery, options_for_select(@delivery_parent_array.map{|c|[c, {}]}, @item.delivery.parent.delivery_method), {}, {class: 'select-default', id: 'parent_delivery__edit'}
+            = f.select :delivery, options_for_select(@delivery_parent_array.map{|c|[c, {}]}, @item.delivery.parent.delivery_method), {}, {class: 'select-default', id: 'parent_delivery_edit'}
           .contents-box__category-section__category-box__tag
             配送の方法
             .form-require
               必須
-            = f.select :delivery_id, options_for_select(@delivery_child_array.map{|c|[c[:delivery_method], c[:id], {'data-category'=>c[:id], 'id'=>c[:id]}]}, @item.delivery.id), {}, {class: 'select-default', id: 'child_delivery__edit'}
+            = f.select :delivery_id, options_for_select(@delivery_child_array.map{|c|[c[:delivery_method], c[:id], {'data-category'=>c[:id], 'id'=>c[:id]}]}, @item.delivery.id), {}, {class: 'select-default', id: 'child_delivery_edit'}
         .contents-box__category-section__category-box
           .contents-box__category-section__category-box__tag
             発送元の地域


### PR DESCRIPTION
# What
商品出品後、商品出品編集を行えます。
今回はカテゴリー欄のjsの動作、及び配送欄のjsの動作を実装しました。
出品時の情報を残している状態から、カテゴリー欄のプルダウンメニューを操作すると
カテゴリーの変更が行えます。
配送欄も同様に行えます。

【商品編集前の状態】
【一覧】
https://gyazo.com/33e98b9ecafc52bc60558b6f08b02868
【詳細画面】
https://gyazo.com/6978c53f9c451a57c76c2d3b9befb7e4

【カテゴリー欄のjsの動き】
【カテゴリー欄】
https://gyazo.com/fa63fdad3b07ab472fa59f51662b9f94

【配送欄】
https://gyazo.com/e634bfc389c415de5b9f6eb8a66d9609

【商品編集後の状態】
【一覧】
https://gyazo.com/c0f1a9c634dea75acf71dc2458f42ebc

【詳細画面】
https://gyazo.com/f4d5fc819797357103c281f28848836d

# Why
メルカリの必須機能実装の為